### PR TITLE
Add .claude and homestak-dev repos to /issues skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.12] - 2025-01-09
+
 ### Added
 - Initial repository setup
 - `/issues` skill for gathering GitHub issues across homestak-dev repos
@@ -13,3 +15,6 @@ All notable changes to this project will be documented in this file.
   - Issue count footer
 - Workspace settings configuration
 - Custom status line script
+
+### Changed
+- `/issues` skill now includes .claude and homestak-dev repos (9 total)

--- a/skills/issues/reference.md
+++ b/skills/issues/reference.md
@@ -54,7 +54,7 @@ gh issue list -R homestak-dev/ansible --json number,title,labels | \
 
 ```bash
 # Loop through all repos
-for repo in ansible bootstrap iac-driver packer site-config tofu .github; do
+for repo in ansible bootstrap iac-driver packer site-config tofu .claude .github homestak-dev; do
   echo "=== $repo ==="
   gh issue list -R "homestak-dev/$repo" --state open
 done
@@ -66,7 +66,7 @@ done
 
 ```bash
 # Get all open issues created in the last 7 days
-for repo in ansible bootstrap iac-driver packer site-config tofu .github; do
+for repo in ansible bootstrap iac-driver packer site-config tofu .claude .github homestak-dev; do
   gh issue list -R "homestak-dev/$repo" --state open \
     --json number,title,createdAt,url | \
     jq --arg since "$(date -d '7 days ago' +%Y-%m-%d)" \
@@ -78,7 +78,7 @@ done
 
 ```bash
 # Find all high-priority issues
-for repo in ansible bootstrap iac-driver packer site-config tofu .github; do
+for repo in ansible bootstrap iac-driver packer site-config tofu .claude .github homestak-dev; do
   gh issue list -R "homestak-dev/$repo" --label "priority:high,critical"
 done
 ```
@@ -88,13 +88,13 @@ done
 ```bash
 # Count issues by state
 echo "Open issues:"
-for repo in ansible bootstrap iac-driver packer site-config tofu .github; do
+for repo in ansible bootstrap iac-driver packer site-config tofu .claude .github homestak-dev; do
   count=$(gh issue list -R "homestak-dev/$repo" --state open --json number | jq 'length')
   echo "  $repo: $count"
 done
 
 echo "Closed issues (last 30 days):"
-for repo in ansible bootstrap iac-driver packer site-config tofu .github; do
+for repo in ansible bootstrap iac-driver packer site-config tofu .claude .github homestak-dev; do
   count=$(gh issue list -R "homestak-dev/$repo" --state closed \
     --json closedAt | \
     jq --arg since "$(date -d '30 days ago' +%Y-%m-%d)" \
@@ -140,7 +140,7 @@ Total: 37 issues
 You can set these in your shell profile for convenience:
 
 ```bash
-export HOMESTAK_REPOS="ansible bootstrap iac-driver packer site-config tofu .github"
+export HOMESTAK_REPOS="ansible bootstrap iac-driver packer site-config tofu .claude .github homestak-dev"
 export HOMESTAK_ORG="homestak-dev"
 ```
 

--- a/skills/issues/scripts/gather-all-issues.sh
+++ b/skills/issues/scripts/gather-all-issues.sh
@@ -11,7 +11,9 @@ REPOS=(
   "homestak-dev/packer"
   "homestak-dev/site-config"
   "homestak-dev/tofu"
+  "homestak-dev/.claude"
   "homestak-dev/.github"
+  "homestak-dev/homestak-dev"
 )
 
 STATE="${1:-open}"


### PR DESCRIPTION
## Summary
- Update /issues skill to include .claude and homestak-dev repos (9 total)
- Update reference.md examples with new repo list
- Add CHANGELOG.md for v0.12

## Test plan
- [ ] Run `/issues` and verify all 9 repos are queried
- [ ] Verify homestak-dev issues appear in output

Closes homestak-dev/homestak-dev#9

Part of v0.12 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)