### PR TITLE
Add 13 lifecycle skills for all phases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,42 @@ Claude Code configuration for the homestak-dev workspace.
 ├── settings.local.json # Local settings (gitignored)
 ├── statusline.sh       # Custom status line script
 └── skills/
-    └── issues/         # /issues skill for GitHub issue tracking
+    ├── issues/              # GitHub issue tracking
+    ├── planning-init/       # Release planning initialization
+    ├── planning-deps/       # Cross-repo dependency analysis
+    ├── planning-conflicts/  # File conflict analysis
+    ├── validate-prereqs/    # Validation prerequisites check
+    ├── validate-run/        # Run validation scenarios
+    ├── merge-pr/            # Create pull requests
+    ├── release-preflight/   # Release preflight checks
+    ├── release-changelog/   # CHANGELOG updates
+    ├── release-validate/    # Release validation
+    ├── release-tag/         # Git tag creation (gate)
+    ├── release-publish/     # GitHub release creation (gate)
+    ├── release-verify/      # Release verification + AAR
+    └── release-housekeeping/ # Branch cleanup
 ```
 
 ## Skills
+
+### Skill Overview
+
+| Skill | Phase | Description |
+|-------|-------|-------------|
+| `/issues` | - | Gather GitHub issues across all repos |
+| `/planning-init` | 10 | Initialize release planning, create issue |
+| `/planning-deps` | 10 | Analyze cross-repo dependencies |
+| `/planning-conflicts` | 10 | Analyze file overlap for branch strategy |
+| `/validate-prereqs` | 40 | Check validation host readiness |
+| `/validate-run` | 40 | Run iac-driver validation scenario |
+| `/merge-pr` | 50 | Create PR with template and linked issues |
+| `/release-preflight` | 60 | Check release prerequisites |
+| `/release-changelog` | 60 | Update CHANGELOGs for release |
+| `/release-validate` | 60 | Run integration tests |
+| `/release-tag` | 60 | Create git tags (human gate) |
+| `/release-publish` | 60 | Create GitHub releases (human gate) |
+| `/release-verify` | 60 | Verify releases and generate AAR |
+| `/release-housekeeping` | 60 | Clean up branches |
 
 ### /issues
 
@@ -26,15 +58,91 @@ Gathers and displays GitHub issues across all homestak-dev repositories.
 /issues open "bug"   # Filter by label
 ```
 
-**Output format:**
-```
-## issue            status description                                        tags
-   .github#10      open   Epic: Define CI/CD strategy for homestak
-   ansible#11      open   Evaluate geerlingguy.ntp for time sync
-   ...
+### Planning Skills
 
-Total: 37 issues
-```
+#### /planning-init
+
+Initialize release planning by loading lifecycle context and creating the release planning issue.
+
+**Usage:** "Initialize v0.35 release planning, theme 'CI/CD', scope #45, #46"
+
+#### /planning-deps
+
+Analyze cross-repo dependencies for sprint scope to identify implementation order.
+
+**Usage:** "Analyze dependencies for iac-driver#45, tofu#12"
+
+#### /planning-conflicts
+
+Analyze file overlap between issues to inform branch/merge strategy.
+
+**Usage:** "Check for conflicts between #19, #6, #27 in packer"
+
+### Validation Skills
+
+#### /validate-prereqs
+
+Check validation host readiness: node config, API token, secrets, packer images, nested virt.
+
+**Usage:** "Check if father is ready for validation"
+
+#### /validate-run
+
+Run iac-driver validation scenario and capture results.
+
+**Usage:** "Run vm-roundtrip on father"
+
+### Merge Skills
+
+#### /merge-pr
+
+Create PR with template, linked issues, and checklist.
+
+**Usage:** "Create PR to close #129 and #130"
+
+### Release Skills
+
+#### /release-preflight
+
+Check release prerequisites (Phase 0-1): repo health, tags, CHANGELOGs.
+
+**Usage:** "Run preflight for v0.34"
+
+#### /release-changelog
+
+Update CHANGELOGs by moving Unreleased content to versioned headers (Phase 2).
+
+**Usage:** "Update CHANGELOGs for v0.34"
+
+#### /release-validate
+
+Run integration tests before tagging (Phase 3).
+
+**Usage:** "Run validation for v0.34 release"
+
+#### /release-tag
+
+Create and push git tags (Phase 4). **Requires human approval.**
+
+**Usage:** "Create tags for v0.34"
+
+#### /release-publish
+
+Create GitHub releases (Phase 5-6). **Requires human approval.**
+
+**Usage:** "Publish v0.34 releases"
+
+#### /release-verify
+
+Verify releases and generate After Action Report (Phase 7-8). Fully automated.
+
+**Usage:** "Verify v0.34 release"
+
+#### /release-housekeeping
+
+Clean up branches after release (Phase 9).
+
+**Usage:** "Run housekeeping for v0.34"
 
 ## Adding New Skills
 

--- a/skills/merge-pr/SKILL.md
+++ b/skills/merge-pr/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: merge-pr
+description: Create PR with template, linked issues, and checklist. Streamlines the merge phase by generating properly formatted PRs.
+allowed-tools:
+  - Bash(gh:*)
+  - Bash(git:*)
+  - Read
+---
+
+# Merge PR
+
+## Overview
+
+Create a pull request with:
+1. Properly formatted title and description
+2. Linked issues (Closes #N)
+3. PR checklist from `50-merge.md`
+4. Testing documentation
+
+## When to Use
+
+- "Create PR for this branch"
+- "Open PR to close issue #45"
+- When ready to merge validated changes
+- After implementation and validation phases
+
+## Inputs
+
+Required:
+- **Branch**: Feature branch name (or current branch)
+- **Issues**: Issue number(s) to close (e.g., "#45" or "#45, #46")
+
+Optional:
+- **Title**: PR title (defaults to branch-derived title)
+- **Summary**: Brief description of changes
+
+## Execution Steps
+
+### Step 1: Verify Branch State
+
+```bash
+# Check current branch
+BRANCH=$(git branch --show-current)
+echo "Current branch: $BRANCH"
+
+# Verify not on master
+if [ "$BRANCH" = "master" ]; then
+  echo "ERROR: Cannot create PR from master"
+  exit 1
+fi
+
+# Check if ahead of master
+AHEAD=$(git rev-list master..$BRANCH --count)
+if [ "$AHEAD" = "0" ]; then
+  echo "ERROR: Branch has no commits ahead of master"
+  exit 1
+fi
+echo "Branch is $AHEAD commits ahead of master"
+```
+
+### Step 2: Check Remote Status
+
+```bash
+# Ensure branch is pushed
+git push -u origin $BRANCH 2>/dev/null || true
+
+# Check for existing PR
+EXISTING=$(gh pr list --head $BRANCH --json number --jq '.[0].number')
+if [ -n "$EXISTING" ]; then
+  echo "NOTE: PR #$EXISTING already exists for this branch"
+fi
+```
+
+### Step 3: Generate PR Body
+
+Use the PR template from `50-merge.md`:
+
+```markdown
+## Summary
+<user-provided summary or generated from commits>
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] Other: <!-- describe -->
+
+## Changes
+<bullet list of key changes>
+
+## Testing
+<validation performed>
+
+## Related Issues
+Closes #<issue-number>
+
+## Checklist
+- [ ] Tests pass locally
+- [ ] Integration test scenario identified and passes
+- [ ] CHANGELOG.md updated (if user-facing change)
+- [ ] CLAUDE.md updated (if architecture changed)
+```
+
+### Step 4: Create PR
+
+```bash
+gh pr create \
+  --title "<type>(<scope>): <summary>" \
+  --body "$(cat <<'EOF'
+<generated body>
+EOF
+)"
+```
+
+### Step 5: Return PR URL
+
+Output the created PR URL for reference.
+
+## PR Title Format
+
+Follow conventional commit format:
+- `fix(<scope>): <summary>` - Bug fixes
+- `feat(<scope>): <summary>` - New features
+- `docs(<scope>): <summary>` - Documentation
+- `refactor(<scope>): <summary>` - Refactoring
+- `test(<scope>): <summary>` - Tests
+
+Examples:
+- `feat(cli): Add --dry-run flag to release command`
+- `fix(config): Handle missing node config gracefully`
+- `docs(lifecycle): Separate retrospective into Phase 70`
+
+## Example Usage
+
+**User:** Create PR for this branch, closes #129 and #130
+
+**Assistant:**
+1. Verify branch state (feature/129-130-lifecycle-skills)
+2. Push branch if needed
+3. Generate PR body with linked issues
+4. Create PR:
+   ```bash
+   gh pr create \
+     --title "feat(skills): Add lifecycle skills for all phases" \
+     --body "..."
+   ```
+5. Return: "Created PR: https://github.com/homestak-dev/homestak-dev/pull/132"
+
+## PR Checklist (from 50-merge.md)
+
+Include in every PR description:
+
+```markdown
+## PR Readiness Checklist
+
+- [ ] Feature tested end-to-end (not just unit tests)
+- [ ] External tool assumptions verified (test actual CLI behavior)
+- [ ] CHANGELOG entry in this PR
+- [ ] CLAUDE.md updated if architecture changed
+- [ ] Performance claims measured (before/after timing)
+- [ ] Prerequisites documented (configs, artifacts, permissions)
+- [ ] Integration test scenario identified
+```
+
+## Notes
+
+- Always verify branch has commits before creating PR
+- Link issues with "Closes #N" to auto-close on merge
+- Don't link release planning issues in scope PRs (prevents premature close)
+- PR title should match primary commit message format

--- a/skills/planning-conflicts/SKILL.md
+++ b/skills/planning-conflicts/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: planning-conflicts
+description: Analyze file overlap between sprint issues to inform branch/merge strategy. Helps prevent rework from conflicting changes.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(gh:*)
+---
+
+# Planning Conflicts
+
+## Overview
+
+Analyze potential file conflicts between issues in the sprint scope to:
+1. Identify files touched by multiple issues
+2. Detect restructure/refactor issues that affect many files
+3. Recommend implementation sequence to minimize rework
+4. Suggest checkpoint/merge strategy
+
+## When to Use
+
+- "Will these issues conflict?"
+- "What order should I implement these?"
+- "Should I combine these into one PR?"
+- When sprint has multiple issues in the same repo
+
+## Inputs
+
+The user should provide:
+- List of issues with brief descriptions of expected changes
+- Or issue numbers to fetch details from GitHub
+
+## Execution Steps
+
+### Step 1: Identify Expected File Changes
+
+For each issue, determine which files will be modified:
+- Read issue description for file references
+- Check related PRs or commits
+- Infer from issue scope (e.g., "add CLI flag" → likely touches main script)
+
+### Step 2: Build Overlap Matrix
+
+Create a matrix showing which issues touch which files:
+
+| File | Issue #1 | Issue #2 | Issue #3 |
+|------|----------|----------|----------|
+| `src/cli.py` | ✓ | ✓ | |
+| `CLAUDE.md` | ✓ | | ✓ |
+| `templates/*.hcl` | | ✓ | ✓ |
+
+### Step 3: Detect High-Impact Issues
+
+Flag issues that are likely to cause conflicts:
+- **Restructure issues**: Move/rename files, change directory structure
+- **Refactor issues**: Touch many files for code quality
+- **Schema changes**: Affect multiple consumers
+
+These should typically be implemented first.
+
+### Step 4: Recommend Sequence
+
+Based on overlap analysis:
+
+1. **Phase 1: Quick wins** - Issues with no overlap, can be done in parallel
+2. **Phase 2: Foundation** - Restructure/refactor issues
+3. **Phase 3: Dependent changes** - Issues that build on Phase 2
+
+### Step 5: Suggest Merge Strategy
+
+| Situation | Recommendation |
+|-----------|----------------|
+| No overlap | Parallel branches, merge independently |
+| Minor overlap | Sequential branches, merge in order |
+| Heavy overlap | Combined PR, implement together |
+| Restructure + dependent | Restructure first, rebase others |
+
+## Example Output
+
+```
+## Conflict Analysis for packer Sprint
+
+### File Overlap
+
+| File | #19 (restructure) | #6 (SSH keys) | #27 (AppArmor) |
+|------|-------------------|---------------|----------------|
+| templates/*.pkr.hcl | ✓ | ✓ | ✓ |
+| scripts/cleanup.sh | ✓ | | |
+| shared/cloud-init/* | | ✓ | |
+
+### High-Impact Issues
+- #19 (restructure) - Moves templates to per-template directories
+  - **Must complete first** - others will need rebase
+
+### Recommended Sequence
+
+**Phase 1: Quick wins (no conflicts)**
+- None - all issues touch template files
+
+**Phase 2: Foundation**
+1. #19 - Directory restructure → merge
+
+**Phase 3: Dependent changes (on new structure)**
+2. #6 - SSH key handling
+3. #27 - AppArmor documentation
+
+### Checkpoint Strategy
+- Merge #19 before starting #6 and #27
+- #6 and #27 can proceed in parallel after #19 merges
+```
+
+## Notes
+
+- This analysis prevents scenarios where restructure invalidates parallel work
+- Consider combining heavily-overlapping issues into single PR
+- Update analysis if scope changes during sprint

--- a/skills/planning-deps/SKILL.md
+++ b/skills/planning-deps/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: planning-deps
+description: Analyze cross-repo dependencies for sprint scope. Use during planning to identify implementation order and dependency chains.
+allowed-tools:
+  - Bash(gh:*)
+  - Read
+  - Grep
+  - Glob
+---
+
+# Planning Dependencies
+
+## Overview
+
+Analyze cross-repository dependencies for issues in the sprint scope to:
+1. Map dependency chains between repos
+2. Identify correct implementation order
+3. Flag blocking dependencies
+
+## When to Use
+
+- "What's the dependency order for these issues?"
+- "Which repo should I implement first?"
+- "Are there cross-repo dependencies in this sprint?"
+- During planning phase when multiple repos are involved
+
+## Inputs
+
+The user should provide:
+- List of issues to analyze (e.g., "iac-driver#45, bootstrap#23, tofu#12")
+- Or repos to examine (e.g., "iac-driver, bootstrap")
+
+## Repository Dependency Order
+
+Per `docs/lifecycle/00-overview.md`, releases follow this dependency order:
+
+```
+.github → .claude → homestak-dev → site-config → tofu → ansible → bootstrap → packer → iac-driver
+```
+
+**Downstream depends on upstream.** Changes to `site-config` may affect all repos to its right.
+
+## Execution Steps
+
+### Step 1: Identify Repos Involved
+
+From the issue list, determine which repos are affected.
+
+### Step 2: Check Cross-Repo References
+
+For each repo, look for:
+- Import statements referencing sibling repos
+- ConfigResolver usage (iac-driver depends on site-config schema)
+- Ansible collection references
+- Tofu module references
+
+```bash
+# Example: Check if iac-driver references site-config schema
+grep -r "site-config" iac-driver/src/
+```
+
+### Step 3: Map to Dependency Order
+
+Compare affected repos against the canonical order:
+
+| Position | Repo | Depends On |
+|----------|------|------------|
+| 1 | .github | - |
+| 2 | .claude | .github |
+| 3 | homestak-dev | .github, .claude |
+| 4 | site-config | homestak-dev |
+| 5 | tofu | site-config |
+| 6 | ansible | site-config, tofu |
+| 7 | bootstrap | ansible, tofu |
+| 8 | packer | bootstrap |
+| 9 | iac-driver | all above |
+
+### Step 4: Identify Implementation Sequence
+
+Report:
+1. Which repo changes should be implemented first
+2. Any blocking dependencies
+3. Whether PRs can be merged in parallel or must be sequential
+
+## Example Output
+
+```
+## Dependency Analysis for v0.35
+
+### Repos Affected
+- site-config (schema change)
+- iac-driver (ConfigResolver update)
+- tofu (new variable)
+
+### Implementation Order
+1. site-config#45 - Schema change (no dependencies)
+2. tofu#12 - New variable (depends on site-config schema)
+3. iac-driver#67 - ConfigResolver (depends on both)
+
+### Notes
+- site-config PR must merge before tofu PR
+- iac-driver can be developed in parallel but merge last
+```
+
+## Notes
+
+- This is an analysis skill; it doesn't make changes
+- Focus on functional dependencies, not just file overlap
+- Consider ConfigResolver as a key integration point

--- a/skills/planning-init/SKILL.md
+++ b/skills/planning-init/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: planning-init
+description: Initialize release planning by loading lifecycle context and creating the release planning issue. Use at the start of each sprint/release cycle.
+allowed-tools:
+  - Bash(gh:*)
+  - Read
+  - Glob
+---
+
+# Planning Init
+
+## Overview
+
+Initialize the planning phase for a new release by:
+1. Loading lifecycle documentation into context
+2. Creating a release planning issue from template
+3. Outputting the planning checklist for reference
+
+This skill addresses context compaction issues by ensuring lifecycle docs are fresh in context at sprint start.
+
+## When to Use
+
+- Starting a new release cycle
+- "Initialize v0.X release planning"
+- "Start planning for the next sprint"
+- "Create release issue for v0.X"
+
+## Inputs
+
+The user should provide:
+- **Version**: Release version (e.g., "0.34")
+- **Theme**: Release theme/title (e.g., "Lifecycle Skills")
+- **Scope**: List of issues to include (e.g., "#129, #130")
+
+## Execution Steps
+
+### Step 1: Load Lifecycle Context
+
+Read the following files to ensure process documentation is in context:
+
+```
+docs/lifecycle/00-overview.md   # Work types, phase matrix, multi-repo structure
+docs/lifecycle/10-planning.md   # Planning activities, checklist
+```
+
+### Step 2: Load Release Issue Template
+
+Read the template:
+
+```
+docs/templates/release-issue.md
+```
+
+### Step 3: Create Release Issue
+
+Use `gh issue create` with the populated template:
+
+```bash
+gh issue create --repo homestak-dev/homestak-dev \
+  --title "vX.Y Release Planning - Theme" \
+  --label "release" \
+  --body "$(cat <<'EOF'
+# Populated template content here
+EOF
+)"
+```
+
+### Step 4: Output Planning Checklist
+
+After creating the issue, output the planning checklist from `10-planning.md`:
+
+```
+## Checklist: Planning Complete
+
+- [ ] Release plan issue created with scope
+- [ ] All items classified by work type
+- [ ] Acceptance criteria identified for each item
+- [ ] Effort estimates assigned
+- [ ] Dependencies mapped
+- [ ] Branch/merge strategy analyzed (if multi-issue sprint)
+- [ ] Issue-level planning documented
+- [ ] Sprint backlog reviewed and approved by human
+```
+
+### Step 5: Return Issue Number
+
+Provide the created issue URL for reference.
+
+## Example
+
+**User:** Initialize planning for v0.35 release, theme "CI/CD Improvements", scope is iac-driver#45, bootstrap#23
+
+**Assistant actions:**
+1. Read `docs/lifecycle/00-overview.md`
+2. Read `docs/lifecycle/10-planning.md`
+3. Read `docs/templates/release-issue.md`
+4. Create issue with populated template
+5. Output planning checklist
+6. Return: "Created release issue: https://github.com/homestak-dev/homestak-dev/issues/132"
+
+## Notes
+
+- This skill only creates the release issue; it does not perform planning activities
+- The user must still complete the planning checklist items manually
+- Loading lifecycle docs ensures process documentation is fresh in context

--- a/skills/release-changelog/SKILL.md
+++ b/skills/release-changelog/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: release-changelog
+description: Update CHANGELOGs for release by moving Unreleased content to versioned headers. Covers Release Phase 2.
+allowed-tools:
+  - Edit
+  - Read
+  - Bash(git:*)
+  - Bash(date:*)
+---
+
+# Release CHANGELOG
+
+## Overview
+
+Update CHANGELOGs for the release (Phase 2 from `60-release.md`):
+1. Move `## Unreleased` content to versioned header
+2. Add release date
+3. Follow repository dependency order
+
+## When to Use
+
+- "Update CHANGELOGs for v0.34"
+- "Prepare CHANGELOGs for release"
+- After preflight checks pass
+
+## Repository Order
+
+Update CHANGELOGs in dependency order:
+
+1. .github
+2. .claude
+3. homestak-dev
+4. site-config
+5. tofu
+6. ansible
+7. bootstrap
+8. packer
+9. iac-driver
+
+## CHANGELOG Format
+
+Transform from:
+```markdown
+## Unreleased
+
+### Features
+- Add foo capability (#123)
+
+### Bug Fixes
+- Fix bar issue (#124)
+```
+
+To:
+```markdown
+## Unreleased
+
+## v0.34 - 2026-01-19
+
+### Features
+- Add foo capability (#123)
+
+### Bug Fixes
+- Fix bar issue (#124)
+```
+
+## Execution Steps
+
+### Step 1: Get Current Date
+
+```bash
+DATE=$(date +%Y-%m-%d)
+echo "Release date: $DATE"
+```
+
+### Step 2: For Each Repository
+
+Read the CHANGELOG.md and identify content under `## Unreleased`.
+
+If there is content:
+1. Keep the `## Unreleased` header (empty)
+2. Add new versioned header below: `## vX.Y - YYYY-MM-DD`
+3. Move all content under the versioned header
+
+If no content under Unreleased:
+- No changes needed (repo unchanged this release)
+
+### Step 3: Use Edit Tool
+
+For each repo with changes:
+
+```
+Edit: CHANGELOG.md
+old_string: |
+  ## Unreleased
+
+  ### Features
+  - Add foo capability (#123)
+new_string: |
+  ## Unreleased
+
+  ## v0.34 - 2026-01-19
+
+  ### Features
+  - Add foo capability (#123)
+```
+
+### Step 4: Verify Changes
+
+```bash
+git diff */CHANGELOG.md
+```
+
+## Example Output
+
+```
+## CHANGELOG Updates for v0.34
+
+| Repo | Status | Changes |
+|------|--------|---------|
+| .github | No changes | - |
+| .claude | Updated | Added skills table |
+| homestak-dev | Updated | Lifecycle restructure |
+| site-config | No changes | - |
+| tofu | No changes | - |
+| ansible | No changes | - |
+| bootstrap | No changes | - |
+| packer | No changes | - |
+| iac-driver | No changes | - |
+
+### Next Steps
+1. Review changes: `git diff */CHANGELOG.md`
+2. Proceed to `/release-validate`
+```
+
+## CHANGELOG Entry Guidelines
+
+Per `30-implementation.md`:
+
+- **Add** - New feature or capability
+- **Fix** - Bug fix
+- **Change** - Modification to existing behavior
+- **Remove** - Removed feature
+- **Deprecate** - Feature marked for future removal
+
+Always include issue reference: `(#123)`
+
+## Notes
+
+- Don't commit yet - changes will be committed with tags
+- Repos with no Unreleased content are skipped
+- Empty Unreleased section is intentional (ready for next release)
+- Use Edit tool for precise changes (not file overwrites)

--- a/skills/release-housekeeping/SKILL.md
+++ b/skills/release-housekeeping/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: release-housekeeping
+description: Clean up branches after release. Covers Release Phase 9.
+allowed-tools:
+  - Bash(git:*)
+  - Bash(gita:*)
+  - Bash(cd:*)
+---
+
+# Release Housekeeping
+
+## Overview
+
+Clean up branches after release (Phase 9 from `60-release.md`):
+1. Delete merged local branches
+2. Prune stale remote tracking refs
+3. Check for unmerged branches
+
+## When to Use
+
+- "Clean up branches after release"
+- "Run housekeeping"
+- After AAR is posted, before retrospective
+
+## Execution Steps
+
+### Step 1: For Each Repository
+
+```bash
+for repo in .claude .github ansible bootstrap homestak-dev iac-driver packer site-config tofu; do
+  echo "=== $repo ==="
+  cd ~/homestak-dev/$repo
+
+  # Delete merged local branches
+  git branch --merged | grep -v master | xargs -r git branch -d
+
+  # Prune stale remote tracking refs
+  git remote prune origin
+
+  # Check for unmerged branches
+  for branch in $(git branch -r | grep -v HEAD | grep -v master); do
+    if [[ -n "$(git diff master..$branch 2>/dev/null)" ]]; then
+      echo "UNMERGED: $branch"
+    fi
+  done
+
+  cd -
+done
+```
+
+### Step 2: Using gita (Parallel)
+
+```bash
+# Check branch status across all repos
+gita shell "git branch -a"
+
+# Prune all repos
+gita shell "git remote prune origin"
+```
+
+### Step 3: Verify Clean State
+
+```bash
+gita ll
+# All repos should show clean status
+```
+
+## Output Format
+
+```
+## Release Housekeeping: v0.34
+
+### Branch Cleanup
+| Repo | Deleted | Pruned | Unmerged |
+|------|---------|--------|----------|
+| .github | 0 | 0 | 0 |
+| .claude | 0 | 0 | 0 |
+| homestak-dev | 1 (feature/129-130-lifecycle-skills) | 0 | 0 |
+| ... | ... | ... | ... |
+
+### Notes
+- Branches may show as "ahead" after squash/rebase merge
+- Use `git diff master..branch` to verify actual unmerged content
+
+### Repository Settings Reminder
+Enable "Automatically delete head branches" in GitHub repo settings
+to auto-cleanup after PR merge.
+
+### Next Steps
+1. Branch cleanup complete
+2. Proceed to Phase 70 (Retrospective)
+```
+
+## Important Notes
+
+### Squash/Rebase Merged Branches
+
+Branches may show as "ahead" by commit count even when content was merged via squash/rebase. Use `git diff` to verify:
+
+```bash
+# Check if branch has actual differences from master
+git diff master..origin/feature-branch
+
+# If empty output, branch can be safely deleted
+git push origin --delete feature-branch
+```
+
+### Auto-Delete Setting
+
+Recommend enabling repository setting:
+- Settings → General → Pull Requests
+- Check "Automatically delete head branches"
+
+## Notes
+
+- Housekeeping is done before Retrospective (moved in v0.24)
+- This allows any cleanup issues to be captured in retrospective
+- Remote branches deleted via PR merge won't appear locally until pruned

--- a/skills/release-preflight/SKILL.md
+++ b/skills/release-preflight/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: release-preflight
+description: Check release prerequisites including repo health, tags, CHANGELOGs, and CLAUDE.md files. Covers Release Phase 0-1.
+allowed-tools:
+  - Bash(git:*)
+  - Bash(gh:*)
+  - Bash(gita:*)
+  - Bash(ls:*)
+  - Bash(grep:*)
+  - Read
+---
+
+# Release Preflight
+
+## Overview
+
+Verify release prerequisites (Phase 0-1 from `60-release.md`):
+1. Release plan refresh (Phase 0)
+2. Pre-flight checks (Phase 1)
+
+## When to Use
+
+- Starting a release
+- "Check if repos are ready for release"
+- "Run preflight for v0.34"
+- After `release.sh init`
+
+## Execution Steps
+
+### Phase 0: Release Plan Refresh
+
+1. **Verify prerequisite releases** - Check previous version tags exist
+2. **Compare against methodology** - Reference `60-release.md`
+3. **Update checklists** - Ensure alignment with current process
+
+### Phase 1: Pre-flight Checks
+
+#### 1.1 Identify Release Issue
+
+```bash
+# Find open release issues
+gh issue list --repo homestak-dev/homestak-dev --label release --state open
+```
+
+#### 1.2 Git Fetch All Repos
+
+```bash
+gita fetch
+```
+
+#### 1.3 Check Working Trees Clean
+
+```bash
+gita shell "git status --porcelain"
+# Should return empty for all repos
+```
+
+#### 1.4 Check No Existing Tags
+
+```bash
+VERSION=0.34  # Set target version
+for repo in .claude .github ansible bootstrap homestak-dev iac-driver packer site-config tofu; do
+  gh api repos/homestak-dev/$repo/git/refs/tags/v${VERSION} 2>/dev/null && \
+    echo "WARNING: $repo has tag v${VERSION}" || echo "OK: $repo no tag"
+done
+```
+
+#### 1.5 Check Secrets Decrypted
+
+```bash
+ls site-config/secrets.yaml 2>/dev/null && echo "OK: secrets decrypted" || \
+  echo "FAIL: secrets.yaml missing - run 'make decrypt' in site-config"
+```
+
+#### 1.6 CLAUDE.md Review
+
+Check each repo's CLAUDE.md reflects current state:
+
+**Meta repos:**
+- [ ] .github - org templates, PR defaults
+- [ ] .claude - skills, settings
+- [ ] homestak-dev - workspace structure, documentation index
+
+**Core repos:**
+- [ ] site-config - schema, defaults, file structure
+- [ ] iac-driver - scenarios, actions, ConfigResolver
+- [ ] tofu - modules, variables, workflow
+- [ ] packer - templates, build workflow
+- [ ] ansible - playbooks, roles, collections
+- [ ] bootstrap - CLI, installation
+
+#### 1.7 Check CHANGELOGs
+
+Verify each repo has unreleased content or is unchanged:
+
+```bash
+for repo in .claude .github ansible bootstrap homestak-dev iac-driver packer site-config tofu; do
+  echo "=== $repo ==="
+  head -20 $repo/CHANGELOG.md 2>/dev/null | grep -A5 "Unreleased"
+done
+```
+
+## Output Format
+
+```
+## Release Preflight: v0.34
+
+### Phase 0: Release Plan Refresh
+- [x] Previous release (v0.33) tags exist
+- [x] Checklist aligned with 60-release.md
+
+### Phase 1: Pre-flight
+| Check | Status | Notes |
+|-------|--------|-------|
+| Release issue | OK | #131 |
+| Git fetch | OK | All repos fetched |
+| Working trees | OK | All clean |
+| No existing tags | OK | v0.34 not found |
+| Secrets decrypted | OK | secrets.yaml exists |
+| CLAUDE.md review | PENDING | Manual review needed |
+| CHANGELOGs | OK | Unreleased content found |
+
+### Next Steps
+1. Review CLAUDE.md files for accuracy
+2. Proceed to `/release-changelog`
+```
+
+## Using release.sh
+
+This skill wraps `release.sh preflight`:
+
+```bash
+./scripts/release.sh preflight
+```
+
+The CLI performs the same checks programmatically.
+
+## Notes
+
+- Run this after `release.sh init --version X.Y --issue N`
+- CLAUDE.md review requires manual verification
+- Packer build smoke test only needed if images changed

--- a/skills/release-publish/SKILL.md
+++ b/skills/release-publish/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: release-publish
+description: Create GitHub releases and handle packer images. Covers Release Phase 5-6. GATE - requires human approval.
+allowed-tools:
+  - Bash(./scripts/release.sh:*)
+  - Bash(gh:*)
+---
+
+# Release Publish
+
+## Overview
+
+Create GitHub releases and handle packer images (Phase 5-6 from `60-release.md`):
+1. Handle packer images (if changed)
+2. Preview release creation (dry-run)
+3. **GATE: Get human approval**
+4. Create GitHub releases
+
+## When to Use
+
+- "Create GitHub releases"
+- "Publish v0.34"
+- After tags are created
+
+## IMPORTANT: Human Gate
+
+This operation creates public releases. Always:
+1. Show dry-run output first
+2. Wait for explicit human approval
+3. Only then execute with `--execute`
+
+## Execution Steps
+
+### Step 1: Check Packer Images
+
+```bash
+./scripts/release.sh packer --check
+```
+
+Determine if images changed:
+- **No changes**: Skip image handling, add note to release
+- **Changes**: Build and update `latest` release
+
+### Step 2: Handle Packer Images (if needed)
+
+If images changed:
+```bash
+# Build and fetch images
+cd iac-driver
+./run.sh --scenario packer-build-fetch --remote father
+
+# Copy to new release
+./scripts/release.sh packer --copy --source v0.34 --execute
+```
+
+If images NOT changed:
+```
+Note: Images unchanged. Releases will reference 'latest' release.
+```
+
+### Step 3: Dry Run
+
+```bash
+./scripts/release.sh publish --dry-run
+```
+
+Expected output:
+```
+Publish dry-run for v0.34
+
+Would create releases:
+  .github:      v0.34 (prerelease)
+  .claude:      v0.34 (prerelease)
+  homestak-dev: v0.34 (prerelease)
+  site-config:  v0.34 (prerelease)
+  tofu:         v0.34 (prerelease)
+  ansible:      v0.34 (prerelease)
+  bootstrap:    v0.34 (prerelease)
+  packer:       v0.34 (prerelease, note: images in 'latest')
+  iac-driver:   v0.34 (prerelease)
+```
+
+### Step 4: Human Approval Gate
+
+Present the dry-run output and ask:
+
+```
+## Release Creation Preview
+
+The following GitHub releases will be created:
+
+| Repo | Version | Prerelease | Images |
+|------|---------|------------|--------|
+| .github | v0.34 | Yes | - |
+| packer | v0.34 | Yes | See 'latest' |
+| ... | ... | ... | ... |
+
+Proceed with release creation? (yes/no)
+```
+
+### Step 5: Execute (After Approval)
+
+**Recommended (fast, server-side):**
+```bash
+./scripts/release.sh publish --execute --workflow github --yes
+```
+
+**Alternative (local, slower):**
+```bash
+./scripts/release.sh publish --execute --workflow local --yes
+```
+
+### Step 6: Verify Releases
+
+```bash
+./scripts/release.sh verify
+```
+
+## Repository Order
+
+Releases are created in dependency order:
+1. .github
+2. .claude
+3. homestak-dev
+4. site-config
+5. tofu
+6. ansible
+7. bootstrap
+8. packer
+9. iac-driver
+
+## Packer Release Notes
+
+Include image status in packer release notes:
+
+**If images NOT changed:**
+```
+Images: See `latest` release for current images.
+```
+
+**If images changed:**
+```
+Images: Included in this release.
+- debian-12-custom.qcow2
+- debian-13-custom.qcow2
+- debian-13-pve.qcow2
+```
+
+## Output Format
+
+```
+## Release Publish: v0.34
+
+### Packer Images
+Status: No changes (using 'latest')
+
+### Dry Run
+[Show dry-run output]
+
+### Human Approval
+**Awaiting approval to proceed...**
+
+### Execution (after approval)
+| Repo | Status | URL |
+|------|--------|-----|
+| .github | Created | https://github.com/homestak-dev/.github/releases/tag/v0.34 |
+| ... | ... | ... |
+
+### Next Steps
+1. Releases created
+2. Proceed to `/release-verify`
+```
+
+## Notes
+
+- **Always use `--workflow github`** for faster server-side processing
+- **Always use `--prerelease`** until v1.0
+- **Never skip the dry-run step**
+- **Never proceed without human approval**
+- Packer images >2GB must be split due to GitHub limits

--- a/skills/release-tag/SKILL.md
+++ b/skills/release-tag/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: release-tag
+description: Create and push git tags for release. Covers Release Phase 4. GATE - requires human approval.
+allowed-tools:
+  - Bash(./scripts/release.sh:*)
+  - Bash(git:*)
+  - Bash(gh:*)
+---
+
+# Release Tag
+
+## Overview
+
+Create and push git tags (Phase 4 from `60-release.md`):
+1. Preview tag creation (dry-run)
+2. **GATE: Get human approval**
+3. Create and push tags
+
+## When to Use
+
+- "Create tags for v0.34"
+- "Tag the release"
+- After validation passes
+
+## IMPORTANT: Human Gate
+
+This is an **irreversible operation**. Always:
+1. Show dry-run output first
+2. Wait for explicit human approval
+3. Only then execute with `--execute`
+
+## Execution Steps
+
+### Step 1: Dry Run
+
+```bash
+./scripts/release.sh tag --dry-run
+```
+
+Expected output:
+```
+Tag dry-run for v0.34
+
+Would create tags:
+  .github:      v0.34
+  .claude:      v0.34
+  homestak-dev: v0.34
+  site-config:  v0.34
+  tofu:         v0.34
+  ansible:      v0.34
+  bootstrap:    v0.34
+  packer:       v0.34
+  iac-driver:   v0.34
+
+Commands that would run:
+  git tag -a v0.34 -m "Release v0.34"
+  git push origin v0.34
+```
+
+### Step 2: Human Approval Gate
+
+Present the dry-run output and ask:
+
+```
+## Tag Creation Preview
+
+The following tags will be created:
+
+| Repo | Tag | Current HEAD |
+|------|-----|--------------|
+| .github | v0.34 | abc1234 |
+| .claude | v0.34 | def5678 |
+| ... | ... | ... |
+
+**This operation cannot be easily undone for stable releases.**
+
+Proceed with tag creation? (yes/no)
+```
+
+### Step 3: Execute (After Approval)
+
+```bash
+./scripts/release.sh tag --execute --yes
+```
+
+Or without `--yes` for interactive confirmation:
+```bash
+./scripts/release.sh tag --execute
+```
+
+### Step 4: Verify Tags
+
+```bash
+for repo in .claude .github ansible bootstrap homestak-dev iac-driver packer site-config tofu; do
+  echo "=== $repo ==="
+  gh api repos/homestak-dev/$repo/git/refs/tags/v0.34 --jq '.ref' 2>/dev/null || echo "NOT FOUND"
+done
+```
+
+## Repository Order
+
+Tags are created in dependency order:
+1. .github
+2. .claude
+3. homestak-dev
+4. site-config
+5. tofu
+6. ansible
+7. bootstrap
+8. packer
+9. iac-driver
+
+## Output Format
+
+```
+## Release Tags: v0.34
+
+### Dry Run
+[Show dry-run output]
+
+### Human Approval
+**Awaiting approval to proceed...**
+
+### Execution (after approval)
+| Repo | Status | Tag |
+|------|--------|-----|
+| .github | Created | v0.34 |
+| .claude | Created | v0.34 |
+| homestak-dev | Created | v0.34 |
+| ... | ... | ... |
+
+### Next Steps
+1. Tags created and pushed
+2. Proceed to `/release-publish`
+```
+
+## Error Recovery
+
+If tag creation fails partway through:
+
+```bash
+# Check which tags exist
+for repo in .claude .github ansible bootstrap homestak-dev iac-driver packer site-config tofu; do
+  gh api repos/homestak-dev/$repo/git/refs/tags/v0.34 2>/dev/null && echo "$repo: EXISTS" || echo "$repo: MISSING"
+done
+
+# For v0.x releases, tags can be reset:
+./scripts/release.sh tag --reset
+```
+
+## Notes
+
+- **Never skip the dry-run step**
+- **Never proceed without human approval**
+- For v0.x releases, tags can be deleted/recreated if needed
+- For v1.0+, tags are permanent
+- Use `--yes` flag only when user has explicitly approved

--- a/skills/release-validate/SKILL.md
+++ b/skills/release-validate/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: release-validate
+description: Run integration tests before tagging. Covers Release Phase 3.
+allowed-tools:
+  - Bash(./scripts/release.sh:*)
+  - Bash(cd:*)
+  - Bash(./run.sh:*)
+  - Bash(cat:*)
+  - Bash(ls:*)
+  - Read
+---
+
+# Release Validate
+
+## Overview
+
+Run integration tests before tagging (Phase 3 from `60-release.md`):
+1. Ensure secrets are decrypted
+2. Run validation scenario
+3. Capture and attach report
+
+## When to Use
+
+- "Run validation for release"
+- "Test before tagging"
+- After CHANGELOGs are updated
+
+## Prerequisite Check
+
+Before validation:
+- [ ] Preflight checks passed (`/release-preflight`)
+- [ ] CHANGELOGs updated (`/release-changelog`)
+- [ ] Secrets decrypted (`site-config/secrets.yaml` exists)
+
+## Execution Steps
+
+### Step 1: Verify Secrets Decrypted
+
+```bash
+if [ ! -f site-config/secrets.yaml ]; then
+  echo "ERROR: Secrets not decrypted"
+  echo "Run: cd site-config && make decrypt"
+  exit 1
+fi
+```
+
+### Step 2: Run Validation
+
+**Using release.sh (recommended):**
+
+```bash
+./scripts/release.sh validate --scenario vm-roundtrip --host father
+```
+
+**Manual execution:**
+
+```bash
+cd iac-driver
+./run.sh --scenario vm-roundtrip --host father --verbose
+```
+
+### Step 3: Check Results
+
+```bash
+# Find latest report
+REPORT=$(ls -t iac-driver/reports/*.md 2>/dev/null | head -1)
+if [ -n "$REPORT" ]; then
+  echo "Report: $REPORT"
+  cat "$REPORT"
+fi
+```
+
+### Step 4: Attach to Release Issue
+
+```bash
+# Get issue number from release state
+ISSUE=$(jq -r '.issue' .release-state.json)
+
+# Post report as comment
+gh issue comment $ISSUE --repo homestak-dev/homestak-dev --body "$(cat <<EOF
+## Validation Report
+
+**Scenario:** vm-roundtrip
+**Host:** father
+**Status:** PASSED
+
+$(cat "$REPORT")
+EOF
+)"
+```
+
+## Validation Scenarios
+
+| Scenario | When to Use | Duration |
+|----------|-------------|----------|
+| `vm-roundtrip` | Default, most releases | ~2 min |
+| `nested-pve-roundtrip` | PVE install changes, full stack | ~9 min |
+
+## Output Format
+
+```
+## Release Validation: v0.34
+
+**Scenario:** vm-roundtrip
+**Host:** father
+**Status:** PASSED
+**Duration:** 1m 52s
+
+### Phase Results
+| Phase | Status | Duration |
+|-------|--------|----------|
+| ensure_image | passed | 2s |
+| provision_vm | passed | 48s |
+| start_vm | passed | 3s |
+| wait_ip | passed | 35s |
+| verify_ssh | passed | 4s |
+| destroy_vm | passed | 20s |
+
+### Report Location
+`iac-driver/reports/20260119-150000.passed.md`
+
+### Next Steps
+1. Report attached to issue #131
+2. Proceed to `/release-tag`
+```
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| "Validation not initialized" | No release state | Run `release.sh init` first |
+| "API token error" | Missing/wrong token | Check site-config secrets |
+| "Image not found" | Missing packer image | Run `./publish.sh` in packer |
+| Scenario fails | Infrastructure issue | Debug with `--verbose`, fix and retry |
+
+## Notes
+
+- Validation is a hard gate - do not proceed to tagging if it fails
+- Always attach report to release issue for audit trail
+- vm-roundtrip is sufficient for most releases
+- Use nested-pve-roundtrip when PVE installation is in scope

--- a/skills/release-verify/SKILL.md
+++ b/skills/release-verify/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: release-verify
+description: Verify releases and generate After Action Report. Covers Release Phase 7-8. Fully automated.
+allowed-tools:
+  - Bash(./scripts/release.sh:*)
+  - Bash(gh:*)
+  - Bash(curl:*)
+  - Read
+---
+
+# Release Verify
+
+## Overview
+
+Verify releases and generate AAR (Phase 7-8 from `60-release.md`):
+1. Verify all releases exist
+2. Check packer images (if applicable)
+3. Run post-release smoke test
+4. Generate and post After Action Report
+
+This skill is **fully automated** - no human gate required.
+
+## When to Use
+
+- "Verify the release"
+- "Check all releases exist"
+- "Generate AAR for v0.34"
+- After releases are published
+
+## Execution Steps
+
+### Step 1: Verify Releases Exist
+
+```bash
+./scripts/release.sh verify
+```
+
+Expected output:
+```
+Verifying v0.34 releases...
+
+| Repo | Release | Assets |
+|------|---------|--------|
+| .github | v0.34 | 0 |
+| .claude | v0.34 | 0 |
+| homestak-dev | v0.34 | 0 |
+| site-config | v0.34 | 0 |
+| tofu | v0.34 | 0 |
+| ansible | v0.34 | 0 |
+| bootstrap | v0.34 | 0 |
+| packer | v0.34 | 0 (images in 'latest') |
+| iac-driver | v0.34 | 0 |
+
+All releases verified.
+```
+
+### Step 2: Post-Release Smoke Test
+
+Test bootstrap installation:
+
+```bash
+# On a clean system (or container)
+curl -fsSL https://raw.githubusercontent.com/homestak-dev/bootstrap/v0.34/install.sh | bash
+homestak --version
+# Should show v0.34
+```
+
+If testing locally:
+```bash
+# Verify install.sh is accessible
+curl -sI https://raw.githubusercontent.com/homestak-dev/bootstrap/v0.34/install.sh | head -1
+# Should return: HTTP/2 200
+```
+
+### Step 3: Verify Scope Issues Closed
+
+```bash
+# Get scope from release issue
+ISSUE=131
+gh issue view $ISSUE --repo homestak-dev/homestak-dev --json body | \
+  jq -r '.body' | grep -oE '#[0-9]+' | sort -u
+
+# Check each issue is closed
+# Close any that were missed
+```
+
+### Step 4: Generate After Action Report
+
+Use data from release state and verification:
+
+```markdown
+## After Action Report: v0.34
+
+### Summary
+- **Version:** v0.34
+- **Theme:** Lifecycle Skills
+- **Started:** 2026-01-19 10:00
+- **Completed:** 2026-01-19 15:30
+- **Duration:** 5h 30m
+
+### Planned vs Actual
+| Aspect | Planned | Actual |
+|--------|---------|--------|
+| Scope items | 2 | 2 |
+| Repos changed | 1 | 1 |
+| Validation | vm-roundtrip | vm-roundtrip |
+
+### Deviations
+- None
+
+### Issues Discovered
+- None
+
+### Artifacts Delivered
+| Repo | Tag | Release | Assets |
+|------|-----|---------|--------|
+| homestak-dev | v0.34 | Yes | 0 |
+| ... | ... | ... | ... |
+
+### Validation Report
+See comment above for full validation results.
+```
+
+### Step 5: Post AAR to Issue
+
+```bash
+ISSUE=131
+gh issue comment $ISSUE --repo homestak-dev/homestak-dev --body "$(cat <<'EOF'
+## After Action Report
+[Generated AAR content]
+EOF
+)"
+```
+
+## Output Format
+
+```
+## Release Verification: v0.34
+
+### Release Status
+| Repo | Status | Assets |
+|------|--------|--------|
+| .github | OK | 0 |
+| .claude | OK | 0 |
+| ... | ... | ... |
+
+### Smoke Test
+- install.sh accessible: OK
+- (Manual bootstrap test recommended on clean system)
+
+### Scope Issues
+- #129: Closed
+- #130: Closed
+
+### After Action Report
+Posted to issue #131
+
+### Next Steps
+1. AAR posted
+2. Proceed to `/release-housekeeping`
+```
+
+## Notes
+
+- This phase is fully automated
+- AAR uses data from release state file
+- Smoke test on clean system is optional but recommended
+- Always verify scope issues are closed before proceeding

--- a/skills/validate-prereqs/SKILL.md
+++ b/skills/validate-prereqs/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: validate-prereqs
+description: Verify validation host is ready for integration tests. Checks node config, API tokens, secrets, packer images, and nested virtualization.
+allowed-tools:
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(grep:*)
+  - Bash(test:*)
+  - Read
+---
+
+# Validate Prerequisites
+
+## Overview
+
+Verify that a host is ready for integration testing by checking:
+1. Node configuration exists
+2. API token is configured
+3. Secrets are decrypted
+4. Packer images are available
+5. Nested virtualization is enabled (if needed)
+
+## When to Use
+
+- Before running integration tests
+- "Is the host ready for validation?"
+- "Check prerequisites for testing on father"
+- When validation fails with config errors
+
+## Inputs
+
+- **Hostname** (optional): Target host to check (defaults to current hostname)
+
+## Prerequisites Checked
+
+| Prerequisite | Check | Remediation |
+|--------------|-------|-------------|
+| Node config | `site-config/nodes/{host}.yaml` exists | Run `make node-config` on host |
+| API token | Token in `secrets.yaml` for host | Run `pveum user token add`, update secrets |
+| Secrets decrypted | `secrets.yaml` exists (not `.enc` only) | Run `make decrypt` in site-config |
+| Packer images | Images in `/var/lib/vz/template/iso/` | Run `./publish.sh` or download from release |
+| Nested virt | `/sys/module/kvm_intel/parameters/nested` = Y | Enable in BIOS/hypervisor |
+
+## Execution Steps
+
+### Step 1: Determine Target Host
+
+```bash
+HOST="${1:-$(hostname)}"
+echo "Checking prerequisites for: $HOST"
+```
+
+### Step 2: Check Node Configuration
+
+```bash
+if [ -f "site-config/nodes/${HOST}.yaml" ]; then
+  echo "OK: Node config exists"
+else
+  echo "FAIL: Missing site-config/nodes/${HOST}.yaml"
+  echo "  Fix: Run 'make node-config' on the host"
+fi
+```
+
+### Step 3: Check API Token
+
+```bash
+if [ -f "site-config/secrets.yaml" ]; then
+  if grep -q "api_tokens:" site-config/secrets.yaml && \
+     grep -q "${HOST}:" site-config/secrets.yaml; then
+    echo "OK: API token found"
+  else
+    echo "FAIL: API token not found for $HOST"
+    echo "  Fix: Run 'pveum user token add root@pam homestak --privsep 0'"
+    echo "       Add token to site-config/secrets.yaml"
+  fi
+else
+  echo "FAIL: secrets.yaml not found (not decrypted?)"
+  echo "  Fix: Run 'make decrypt' in site-config/"
+fi
+```
+
+### Step 4: Check Packer Images
+
+```bash
+IMAGES=$(ls /var/lib/vz/template/iso/debian-*-custom.img 2>/dev/null | wc -l)
+if [ "$IMAGES" -gt 0 ]; then
+  echo "OK: Found $IMAGES packer images"
+  ls /var/lib/vz/template/iso/debian-*-custom.img
+else
+  echo "FAIL: No packer images found"
+  echo "  Fix: Run './publish.sh' in packer/ or download from release"
+fi
+```
+
+### Step 5: Check Nested Virtualization
+
+```bash
+if [ -f /sys/module/kvm_intel/parameters/nested ]; then
+  NESTED=$(cat /sys/module/kvm_intel/parameters/nested)
+  if [ "$NESTED" = "Y" ] || [ "$NESTED" = "1" ]; then
+    echo "OK: Nested virtualization enabled"
+  else
+    echo "WARN: Nested virtualization disabled"
+    echo "  Note: Only required for nested-pve scenarios"
+  fi
+else
+  echo "WARN: Cannot check nested virtualization (not on Intel?)"
+fi
+```
+
+### Step 6: Summary
+
+Output overall status:
+
+```
+## Prerequisite Check Summary
+
+Host: father
+Status: READY / NOT READY
+
+| Check | Status | Action |
+|-------|--------|--------|
+| Node config | OK | - |
+| API token | OK | - |
+| Secrets | OK | - |
+| Packer images | OK | 3 images |
+| Nested virt | OK | - |
+```
+
+## Example Output
+
+```
+Checking prerequisites for: father
+
+OK: Node config exists (site-config/nodes/father.yaml)
+OK: API token found
+OK: Secrets decrypted
+OK: Found 3 packer images
+  - debian-12-custom.img
+  - debian-13-custom.img
+  - debian-13-pve.img
+OK: Nested virtualization enabled
+
+Status: READY for integration testing
+```
+
+## Notes
+
+- Run this before `validate-run` to catch config issues early
+- Nested virtualization only required for `nested-pve-*` scenarios
+- API token issues are the most common cause of validation failures

--- a/skills/validate-run/SKILL.md
+++ b/skills/validate-run/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: validate-run
+description: Run iac-driver validation scenario and capture results. Use during validation phase to execute integration tests.
+allowed-tools:
+  - Bash(cd:*)
+  - Bash(./run.sh:*)
+  - Bash(cat:*)
+  - Bash(ls:*)
+  - Read
+---
+
+# Validate Run
+
+## Overview
+
+Execute an iac-driver validation scenario and:
+1. Run the specified scenario
+2. Capture the test report
+3. Format results summary
+4. Optionally post results to release issue
+
+## When to Use
+
+- "Run vm-roundtrip on father"
+- "Execute validation tests"
+- "Test the release on father"
+- During validation phase before tagging
+
+## Inputs
+
+Required:
+- **Scenario**: Test scenario name (e.g., `vm-roundtrip`, `nested-pve-roundtrip`)
+- **Host**: Target PVE host (e.g., `father`, `mother`)
+
+Optional:
+- **Context file**: Path for context persistence between runs
+- **Issue**: Release issue number to post results
+
+## Available Scenarios
+
+| Scenario | Duration | Purpose |
+|----------|----------|---------|
+| `vm-roundtrip` | ~2 min | Quick validation (provision → boot → verify → destroy) |
+| `nested-pve-roundtrip` | ~9 min | Full stack (including PVE installation) |
+| `vm-constructor` | ~1.5 min | Deploy VM only (no destroy) |
+| `vm-destructor` | ~30 sec | Destroy existing VM |
+
+## Execution Steps
+
+### Step 1: Run Scenario
+
+```bash
+cd iac-driver
+./run.sh --scenario <scenario> --host <host> --verbose
+```
+
+Example:
+```bash
+./run.sh --scenario vm-roundtrip --host father --verbose
+```
+
+### Step 2: Locate Report
+
+Reports are generated in `iac-driver/reports/` with format:
+```
+YYYYMMDD-HHMMSS.{passed|failed}.{md|json}
+```
+
+```bash
+# Find most recent report
+ls -t iac-driver/reports/*.md | head -1
+```
+
+### Step 3: Read Report Content
+
+```bash
+cat iac-driver/reports/<latest-report>.md
+```
+
+### Step 4: Format Summary
+
+Extract key information:
+- Scenario name
+- Pass/fail status
+- Duration
+- Phase breakdown
+
+Example summary:
+```
+## Validation Results
+
+**Scenario:** vm-roundtrip
+**Host:** father
+**Status:** PASSED
+**Duration:** 1m 47s
+
+### Phase Results
+| Phase | Status | Duration |
+|-------|--------|----------|
+| ensure_image | passed | 2s |
+| provision_vm | passed | 45s |
+| start_vm | passed | 3s |
+| wait_ip | passed | 32s |
+| verify_ssh | passed | 5s |
+| destroy_vm | passed | 20s |
+
+**Report:** iac-driver/reports/20260119-143052.passed.md
+```
+
+### Step 5: Post to Issue (Optional)
+
+If issue number provided:
+```bash
+gh issue comment <issue> --repo homestak-dev/homestak-dev --body "$(cat <<'EOF'
+## Validation Results
+...
+EOF
+)"
+```
+
+## Example Usage
+
+**User:** Run vm-roundtrip validation on father and post to issue #131
+
+**Assistant:**
+1. Execute: `cd iac-driver && ./run.sh --scenario vm-roundtrip --host father --verbose`
+2. Wait for completion
+3. Read report from `reports/`
+4. Format summary
+5. Post to issue #131
+6. Report: "Validation passed. Results posted to #131"
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| "API token not found" | Missing/wrong token | Run `/validate-prereqs` first |
+| "Image not found" | Missing packer images | Publish images or download from release |
+| "Connection refused" | PVE not accessible | Check network, PVE status |
+| "Nested virt disabled" | Hardware config | Enable nested virt for nested-pve scenarios |
+
+## Notes
+
+- Always run `/validate-prereqs` before this skill
+- Reports are retained in `iac-driver/reports/` for audit
+- Use `--verbose` flag for detailed output during execution
+- Context files enable running constructor/destructor separately


### PR DESCRIPTION
## Summary

- Add 13 new Claude Code skills covering all lifecycle phases
- Update CLAUDE.md with complete skill documentation
- Update CHANGELOG

Part of homestak-dev#129, homestak-dev#130

## New Skills

### Planning Phase (10)
- `/planning-init` - Initialize release planning, create issue
- `/planning-deps` - Analyze cross-repo dependencies
- `/planning-conflicts` - Analyze file overlap for branch strategy

### Validation Phase (40)
- `/validate-prereqs` - Check validation host readiness
- `/validate-run` - Run iac-driver validation scenario

### Merge Phase (50)
- `/merge-pr` - Create PR with template and linked issues

### Release Phase (60)
- `/release-preflight` - Phase 0-1: Check prerequisites
- `/release-changelog` - Phase 2: Update CHANGELOGs
- `/release-validate` - Phase 3: Run integration tests
- `/release-tag` - Phase 4: Create git tags (human gate)
- `/release-publish` - Phase 5-6: Create GitHub releases (human gate)
- `/release-verify` - Phase 7-8: Verify releases + AAR
- `/release-housekeeping` - Phase 9: Branch cleanup

## Test plan

- [x] All YAML frontmatter valid
- [x] Skill names match directory names
- [x] Allowed-tools appropriate for each skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)